### PR TITLE
feat: add telegram click tracking analytics

### DIFF
--- a/src/components/container/HomePage/DemoSection.vue
+++ b/src/components/container/HomePage/DemoSection.vue
@@ -252,9 +252,11 @@ const dividendsReport = getDividendsReport()
 import { handleTelegramLink } from '@/helpers/telegram'
 import { useDonateModal } from '@/composables/useDonateModal'
 import { useClipboard } from '@/composables/useClipboard'
+import { useAnalytics } from '@/composables/useAnalytics'
 
 const { openModal: openDonateModal } = useDonateModal()
 const { copy, copiedKey } = useClipboard()
+const { trackTelegramClick } = useAnalytics()
 
 const activeTab = ref<'demo' | 'download'>('demo')
 
@@ -365,6 +367,7 @@ watch(isLoading, () => {
 })
 
 function handleTelegramClick(event: Event) {
+  trackTelegramClick('demo-disclaimer')
   handleTelegramLink(event, 'investuvayco')
 }
 </script>

--- a/src/components/container/HomePage/TheFooter.vue
+++ b/src/components/container/HomePage/TheFooter.vue
@@ -168,10 +168,13 @@
 <script setup lang="ts">
 import { handleTelegramLink } from '@/helpers/telegram'
 import { useDonateModal } from '@/composables/useDonateModal'
+import { useAnalytics } from '@/composables/useAnalytics'
 
 const { openModal: openDonateModal } = useDonateModal()
+const { trackTelegramClick } = useAnalytics()
 
 function handleTelegramChatClick(event: Event) {
+  trackTelegramClick('footer')
   handleTelegramLink(event, 'investuvayco')
 }
 </script>

--- a/src/composables/useAnalytics.ts
+++ b/src/composables/useAnalytics.ts
@@ -85,6 +85,13 @@ export function useAnalytics() {
     })
   }
 
+  const trackTelegramClick = (location: string): void => {
+    trackEvent('telegram_click', {
+      event_category: 'engagement',
+      event_label: location
+    })
+  }
+
   return {
     isEnabled,
     trackPageView,
@@ -96,6 +103,7 @@ export function useAnalytics() {
     trackCtaClick,
     trackFaqExpanded,
     trackDonateModalOpened,
-    trackDonateAddressCopied
+    trackDonateAddressCopied,
+    trackTelegramClick
   }
 }

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -35,8 +35,12 @@
 import { handleTelegramLink } from '@/helpers/telegram'
 import { useSeo } from '@/composables/useSeo'
 import { seoConfig } from '@/config/seo'
+import { useAnalytics } from '@/composables/useAnalytics'
+
+const { trackTelegramClick } = useAnalytics()
 
 function handleTelegramClick(event: Event) {
+  trackTelegramClick('about-page')
   handleTelegramLink(event, 'investuvayco')
 }
 

--- a/src/pages/GuidePage.vue
+++ b/src/pages/GuidePage.vue
@@ -355,6 +355,7 @@
             target="_blank"
             rel="noopener"
             class="text-neon-green underline hover:opacity-80"
+            @click="handleTelegramClick"
             >Telegram-канал</a
           >
           . Офіційний портал ДПС:
@@ -390,8 +391,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { useAnalytics } from '@/composables/useAnalytics'
 
+const { trackTelegramClick } = useAnalytics()
 const openedSrc = ref<string | null>(null)
+
+function handleTelegramClick() {
+  trackTelegramClick('guide-page')
+}
 
 function openImage(event: MouseEvent) {
   const target = event.currentTarget as HTMLImageElement

--- a/src/pages/PolicyPage.vue
+++ b/src/pages/PolicyPage.vue
@@ -214,8 +214,12 @@
 import { handleTelegramLink } from '@/helpers/telegram'
 import { useSeo } from '@/composables/useSeo'
 import { seoConfig } from '@/config/seo'
+import { useAnalytics } from '@/composables/useAnalytics'
+
+const { trackTelegramClick } = useAnalytics()
 
 function handleTelegramClick(event: Event) {
+  trackTelegramClick('policy-page')
   handleTelegramLink(event, 'investuvayco')
 }
 

--- a/src/pages/TermsPage.vue
+++ b/src/pages/TermsPage.vue
@@ -536,8 +536,12 @@
 import { handleTelegramLink } from '@/helpers/telegram'
 import { useSeo } from '@/composables/useSeo'
 import { seoConfig } from '@/config/seo'
+import { useAnalytics } from '@/composables/useAnalytics'
+
+const { trackTelegramClick } = useAnalytics()
 
 function handleTelegramClick(event: Event) {
+  trackTelegramClick('terms-page')
   handleTelegramLink(event, 'investuvayco')
 }
 


### PR DESCRIPTION
Track clicks on Telegram channel links in footer and demo section to measure engagement with community channel.